### PR TITLE
ITK filters: fixes for PR

### DIFF
--- a/src-plugins/itkFilters/itkFiltersAddProcess.h
+++ b/src-plugins/itkFilters/itkFiltersAddProcess.h
@@ -23,10 +23,14 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersAddProcess : public itkFiltersProcessBas
     Q_OBJECT
     
 public:
+    static const double defaultAddValue;
+
     itkFiltersAddProcess(itkFiltersAddProcess * parent = 0);
     itkFiltersAddProcess(const itkFiltersAddProcess& other);
     virtual ~itkFiltersAddProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersBinaryCloseProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersBinaryCloseProcess.cpp
@@ -15,18 +15,16 @@
 itkFiltersBinaryCloseProcess::itkFiltersBinaryCloseProcess(itkFiltersBinaryCloseProcess *parent)
     : itkMorphologicalFiltersProcessBase(parent)
 {
-    descriptionText = tr("Binary Close filter");
-}
-
-itkFiltersBinaryCloseProcess::itkFiltersBinaryCloseProcess(const itkFiltersBinaryCloseProcess& other)
-     : itkMorphologicalFiltersProcessBase(other)
-{
-
 }
 
 bool itkFiltersBinaryCloseProcess::registered( void )
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("itkBinaryCloseProcess", createitkFiltersBinaryCloseProcess);
+}
+
+QString itkFiltersBinaryCloseProcess::description() const
+{
+    return tr("Binary Close filter");
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src-plugins/itkFilters/itkFiltersBinaryCloseProcess.h
+++ b/src-plugins/itkFilters/itkFiltersBinaryCloseProcess.h
@@ -17,8 +17,10 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersBinaryCloseProcess : public itkMorpholog
 
 public:
     itkFiltersBinaryCloseProcess(itkFiltersBinaryCloseProcess * parent = 0);
-    itkFiltersBinaryCloseProcess(const itkFiltersBinaryCloseProcess& other);
+
     static bool registered ( void );
+
+    virtual QString description(void) const;
 };
 
 dtkAbstractProcess * createitkFiltersBinaryCloseProcess(void);

--- a/src-plugins/itkFilters/itkFiltersBinaryOpenProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersBinaryOpenProcess.cpp
@@ -15,18 +15,16 @@
 itkFiltersBinaryOpenProcess::itkFiltersBinaryOpenProcess(itkFiltersBinaryOpenProcess *parent)
     : itkMorphologicalFiltersProcessBase(parent)
 {
-    descriptionText = tr("Binary Open filter");
-}
-
-itkFiltersBinaryOpenProcess::itkFiltersBinaryOpenProcess(const itkFiltersBinaryOpenProcess& other)
-     : itkMorphologicalFiltersProcessBase(other)
-{
-
 }
 
 bool itkFiltersBinaryOpenProcess::registered( void )
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("itkBinaryOpenProcess", createitkFiltersBinaryOpenProcess);
+}
+
+QString itkFiltersBinaryOpenProcess::description() const
+{
+    return tr("Binary Open filter");
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src-plugins/itkFilters/itkFiltersBinaryOpenProcess.h
+++ b/src-plugins/itkFilters/itkFiltersBinaryOpenProcess.h
@@ -17,8 +17,10 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersBinaryOpenProcess : public itkMorphologi
 
 public:
     itkFiltersBinaryOpenProcess(itkFiltersBinaryOpenProcess * parent = 0);
-    itkFiltersBinaryOpenProcess(const itkFiltersBinaryOpenProcess& other);
+
     static bool registered ( void );
+
+    virtual QString description(void) const;
 };
 
 dtkAbstractProcess * createitkFiltersBinaryOpenProcess(void);

--- a/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.h
+++ b/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.h
@@ -23,10 +23,14 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersComponentSizeThresholdProcess : public i
     Q_OBJECT
     
 public:
+    static const double defaultMinimumSize;
+
     itkFiltersComponentSizeThresholdProcess(itkFiltersComponentSizeThresholdProcess * parent = 0);
     itkFiltersComponentSizeThresholdProcess(const itkFiltersComponentSizeThresholdProcess& other);
     virtual ~itkFiltersComponentSizeThresholdProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersDilateProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersDilateProcess.cpp
@@ -20,13 +20,6 @@
 itkFiltersDilateProcess::itkFiltersDilateProcess(itkFiltersDilateProcess *parent) 
     : itkMorphologicalFiltersProcessBase(parent)
 {  
-    descriptionText = tr("Dilate filter");
-}
-
-itkFiltersDilateProcess::itkFiltersDilateProcess(const itkFiltersDilateProcess& other)
-     : itkMorphologicalFiltersProcessBase(other)
-{
-
 }
 
 //-------------------------------------------------------------------------------------------
@@ -34,6 +27,11 @@ itkFiltersDilateProcess::itkFiltersDilateProcess(const itkFiltersDilateProcess& 
 bool itkFiltersDilateProcess::registered( void )
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("itkDilateProcess", createitkFiltersDilateProcess);
+}
+
+QString itkFiltersDilateProcess::description() const
+{
+    return tr("Dilate filter");
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src-plugins/itkFilters/itkFiltersDilateProcess.h
+++ b/src-plugins/itkFilters/itkFiltersDilateProcess.h
@@ -21,8 +21,10 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersDilateProcess : public itkMorphologicalF
     
 public:
     itkFiltersDilateProcess(itkFiltersDilateProcess * parent = 0);
-    itkFiltersDilateProcess(const itkFiltersDilateProcess& other);
+
     static bool registered ( void );
+
+    virtual QString description(void) const;
 };
 
 dtkAbstractProcess * createitkFiltersDilateProcess(void);

--- a/src-plugins/itkFilters/itkFiltersDivideProcess.h
+++ b/src-plugins/itkFilters/itkFiltersDivideProcess.h
@@ -23,10 +23,14 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersDivideProcess : public itkFiltersProcess
     Q_OBJECT
     
 public:
+    static const double defaultDivideFactor;
+
     itkFiltersDivideProcess(itkFiltersDivideProcess * parent = 0);
     itkFiltersDivideProcess(const itkFiltersDivideProcess& other);
     virtual ~itkFiltersDivideProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersErodeProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersErodeProcess.cpp
@@ -20,13 +20,6 @@
 itkFiltersErodeProcess::itkFiltersErodeProcess(itkFiltersErodeProcess *parent) 
     : itkMorphologicalFiltersProcessBase(parent)
 {
-    descriptionText = tr("Erode filter");
-}
-
-itkFiltersErodeProcess::itkFiltersErodeProcess(const itkFiltersErodeProcess& other)
-     : itkMorphologicalFiltersProcessBase(other)
-{
-
 }
 
 //-------------------------------------------------------------------------------------------
@@ -34,6 +27,11 @@ itkFiltersErodeProcess::itkFiltersErodeProcess(const itkFiltersErodeProcess& oth
 bool itkFiltersErodeProcess::registered( void )
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("itkErodeProcess", createitkFiltersErodeProcess);
+}
+
+QString itkFiltersErodeProcess::description() const
+{
+    return tr("Erode filter");
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src-plugins/itkFilters/itkFiltersErodeProcess.h
+++ b/src-plugins/itkFilters/itkFiltersErodeProcess.h
@@ -21,8 +21,9 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersErodeProcess : public itkMorphologicalFi
     
 public:
     itkFiltersErodeProcess(itkFiltersErodeProcess * parent = 0);
-    itkFiltersErodeProcess(const itkFiltersErodeProcess& other);
     static bool registered ( void );
+
+    virtual QString description(void) const;
 };
 
 dtkAbstractProcess * createitkFiltersErodeProcess(void);

--- a/src-plugins/itkFilters/itkFiltersGaussianProcess.h
+++ b/src-plugins/itkFilters/itkFiltersGaussianProcess.h
@@ -23,10 +23,14 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersGaussianProcess : public itkFiltersProce
     Q_OBJECT
     
 public:
+    static const double defaultSigma;
+
     itkFiltersGaussianProcess(itkFiltersGaussianProcess * parent = 0);
     itkFiltersGaussianProcess(const itkFiltersGaussianProcess& other);
     virtual ~itkFiltersGaussianProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersGrayscaleCloseProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersGrayscaleCloseProcess.cpp
@@ -15,18 +15,16 @@
 itkFiltersGrayscaleCloseProcess::itkFiltersGrayscaleCloseProcess(itkFiltersGrayscaleCloseProcess *parent)
     : itkMorphologicalFiltersProcessBase(parent)
 {
-    descriptionText = tr("Grayscale Close filter");
-}
-
-itkFiltersGrayscaleCloseProcess::itkFiltersGrayscaleCloseProcess(const itkFiltersGrayscaleCloseProcess& other)
-     : itkMorphologicalFiltersProcessBase(other)
-{
-
 }
 
 bool itkFiltersGrayscaleCloseProcess::registered( void )
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("itkGrayscaleCloseProcess", createitkFiltersGrayscaleCloseProcess);
+}
+
+QString itkFiltersGrayscaleCloseProcess::description() const
+{
+    return tr("Grayscale Close filter");
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src-plugins/itkFilters/itkFiltersGrayscaleCloseProcess.h
+++ b/src-plugins/itkFilters/itkFiltersGrayscaleCloseProcess.h
@@ -17,8 +17,10 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersGrayscaleCloseProcess : public itkMorpho
 
 public:
     itkFiltersGrayscaleCloseProcess(itkFiltersGrayscaleCloseProcess * parent = 0);
-    itkFiltersGrayscaleCloseProcess(const itkFiltersGrayscaleCloseProcess& other);
+
     static bool registered ( void );
+
+    virtual QString description(void) const;
 };
 
 dtkAbstractProcess * createitkFiltersGrayscaleCloseProcess(void);

--- a/src-plugins/itkFilters/itkFiltersGrayscaleOpenProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersGrayscaleOpenProcess.cpp
@@ -15,18 +15,16 @@
 itkFiltersGrayscaleOpenProcess::itkFiltersGrayscaleOpenProcess(itkFiltersGrayscaleOpenProcess *parent)
     : itkMorphologicalFiltersProcessBase(parent)
 {
-    descriptionText = tr("Grayscale Open filter");
-}
-
-itkFiltersGrayscaleOpenProcess::itkFiltersGrayscaleOpenProcess(const itkFiltersGrayscaleOpenProcess& other)
-     : itkMorphologicalFiltersProcessBase(other)
-{
-
 }
 
 bool itkFiltersGrayscaleOpenProcess::registered( void )
 {
     return dtkAbstractProcessFactory::instance()->registerProcessType("itkGrayscaleOpenProcess", createitkFiltersGrayscaleOpenProcess);
+}
+
+QString itkFiltersGrayscaleOpenProcess::description() const
+{
+    return tr("Grayscale Open filter");
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src-plugins/itkFilters/itkFiltersGrayscaleOpenProcess.h
+++ b/src-plugins/itkFilters/itkFiltersGrayscaleOpenProcess.h
@@ -17,8 +17,10 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersGrayscaleOpenProcess : public itkMorphol
 
 public:
     itkFiltersGrayscaleOpenProcess(itkFiltersGrayscaleOpenProcess * parent = 0);
-    itkFiltersGrayscaleOpenProcess(const itkFiltersGrayscaleOpenProcess& other);
+
     static bool registered ( void );
+
+    virtual QString description(void) const;
 };
 
 dtkAbstractProcess * createitkFiltersGrayscaleOpenProcess(void);

--- a/src-plugins/itkFilters/itkFiltersInvertProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersInvertProcess.cpp
@@ -23,13 +23,6 @@
 itkFiltersInvertProcess::itkFiltersInvertProcess(itkFiltersInvertProcess *parent)
     : itkFiltersProcessBase(parent)
 {
-    descriptionText = tr("ITK invert intensity filter");
-}
-
-itkFiltersInvertProcess::itkFiltersInvertProcess(const itkFiltersInvertProcess& other)
-     : itkFiltersProcessBase(other)
-{
-
 }
 
 //-------------------------------------------------------------------------------------------
@@ -41,13 +34,20 @@ bool itkFiltersInvertProcess::registered( void )
 
 //-------------------------------------------------------------------------------------------
 
+QString itkFiltersInvertProcess::description() const
+{
+    return tr("ITK invert intensity filter");
+}
+
+//-------------------------------------------------------------------------------------------
+
 int itkFiltersInvertProcess::tryUpdate()
 {
     int res = DTK_FAILURE;
 
-    if ( inputData )
+    if ( getInputData() )
     {
-        QString id = inputData->identifier();
+        QString id = getInputData()->identifier();
 
         if ( id == "itkDataImageChar3" )
         {
@@ -105,25 +105,25 @@ template <class PixelType> int itkFiltersInvertProcess::updateProcess()
     typedef itk::MinimumMaximumImageCalculator< ImageType > MinMaxFilterType;
     typename MinMaxFilterType::Pointer maxFilter = MinMaxFilterType::New();
 
-    maxFilter->SetImage( dynamic_cast<ImageType *> ( ( itk::Object* ) ( inputData->data() ) ) );
+    maxFilter->SetImage( dynamic_cast<ImageType *> ( ( itk::Object* ) ( getInputData()->data() ) ) );
     maxFilter->Compute();
     PixelType maximum = maxFilter->GetMaximum();
     PixelType minimum = maxFilter->GetMinimum();
 
-    invertFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( inputData->data() ) ) );
+    invertFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( getInputData()->data() ) ) );
     invertFilter->SetMaximum(maximum + minimum);
 
-    callback = itk::CStyleCommand::New();
+    itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
     callback->SetClientData ( ( void * ) this );
     callback->SetCallback ( itkFiltersProcessBase::eventCallback );
     invertFilter->AddObserver ( itk::ProgressEvent(), callback );
 
     invertFilter->Update();
 
-    outputData->setData ( invertFilter->GetOutput() );
+    getOutputData()->setData ( invertFilter->GetOutput() );
 
     //Set output description metadata
-    medUtilities::setDerivedMetaData(outputData, inputData, "invert filter");
+    medUtilities::setDerivedMetaData(getOutputData(), getInputData(), "invert filter");
 
     return DTK_SUCCEED;
 }

--- a/src-plugins/itkFilters/itkFiltersInvertProcess.h
+++ b/src-plugins/itkFilters/itkFiltersInvertProcess.h
@@ -23,8 +23,9 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersInvertProcess : public itkFiltersProcess
     
 public:
     itkFiltersInvertProcess(itkFiltersInvertProcess * parent = 0);
-    itkFiltersInvertProcess(const itkFiltersInvertProcess& other);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
@@ -25,13 +25,6 @@
 itkFiltersMedianProcess::itkFiltersMedianProcess(itkFiltersMedianProcess *parent) 
     : itkFiltersProcessBase(parent)
 {
-    descriptionText = tr("ITK median filter");
-}
-
-itkFiltersMedianProcess::itkFiltersMedianProcess(const itkFiltersMedianProcess& other)
-     : itkFiltersProcessBase(other)
-{
-
 }
 
 //-------------------------------------------------------------------------------------------
@@ -43,13 +36,20 @@ bool itkFiltersMedianProcess::registered( void )
 
 //-------------------------------------------------------------------------------------------
 
+QString itkFiltersMedianProcess::description() const
+{
+    return tr("ITK median filter");
+}
+
+//-------------------------------------------------------------------------------------------
+
 int itkFiltersMedianProcess::tryUpdate()
 {
     int res = DTK_FAILURE;
 
-    if ( inputData )
+    if ( getInputData() )
     {
-        QString id = inputData->identifier();
+        QString id = getInputData()->identifier();
 
         if ( id == "itkDataImageChar3" )
         {
@@ -106,19 +106,19 @@ template <class PixelType> int itkFiltersMedianProcess::updateProcess()
     typedef itk::MedianImageFilter< ImageType, ImageType >  MedianFilterType;
     typename MedianFilterType::Pointer medianFilter = MedianFilterType::New();
 
-    medianFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( inputData->data() ) ) );
+    medianFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( getInputData()->data() ) ) );
 
-    callback = itk::CStyleCommand::New();
+    itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
     callback->SetClientData ( ( void * ) this );
     callback->SetCallback ( itkFiltersProcessBase::eventCallback );
     medianFilter->AddObserver ( itk::ProgressEvent(), callback );
 
     medianFilter->Update();
 
-    outputData->setData ( medianFilter->GetOutput() );
+    getOutputData()->setData ( medianFilter->GetOutput() );
 
     //Set output description metadata
-    medUtilities::setDerivedMetaData(outputData, inputData, "median filter");
+    medUtilities::setDerivedMetaData(getOutputData(), getInputData(), "median filter");
 
     return DTK_SUCCEED;
 }

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.h
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.h
@@ -23,8 +23,10 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersMedianProcess : public itkFiltersProcess
     
 public:
     itkFiltersMedianProcess(itkFiltersMedianProcess * parent = 0);
-    itkFiltersMedianProcess(const itkFiltersMedianProcess& other);
+
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersMultiplyProcess.h
+++ b/src-plugins/itkFilters/itkFiltersMultiplyProcess.h
@@ -23,10 +23,14 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersMultiplyProcess : public itkFiltersProce
     Q_OBJECT
     
 public:
+    static const double defaultMultiplyFactor;
+
     itkFiltersMultiplyProcess(itkFiltersMultiplyProcess * parent = 0);
     itkFiltersMultiplyProcess(const itkFiltersMultiplyProcess& other);
     virtual ~itkFiltersMultiplyProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersNormalizeProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersNormalizeProcess.cpp
@@ -24,14 +24,7 @@
 
 itkFiltersNormalizeProcess::itkFiltersNormalizeProcess(itkFiltersNormalizeProcess *parent) 
     : itkFiltersProcessBase(parent)
-{   
-    descriptionText = tr("ITK normalize filter");
-}
-
-itkFiltersNormalizeProcess::itkFiltersNormalizeProcess(const itkFiltersNormalizeProcess& other)
-     : itkFiltersProcessBase(other)
 {
-
 }
 
 //-------------------------------------------------------------------------------------------
@@ -43,13 +36,20 @@ bool itkFiltersNormalizeProcess::registered( void )
 
 //-------------------------------------------------------------------------------------------
 
+QString itkFiltersNormalizeProcess::description() const
+{
+    return tr("ITK normalize filter");
+}
+
+//-------------------------------------------------------------------------------------------
+
 int itkFiltersNormalizeProcess::tryUpdate()
 {   
     int res = DTK_FAILURE;
 
-    if ( inputData )
+    if ( getInputData() )
     {
-        QString id = inputData->identifier();
+        QString id = getInputData()->identifier();
 
         if ( id == "itkDataImageChar3" )
         {
@@ -106,19 +106,19 @@ template <class PixelType> int itkFiltersNormalizeProcess::updateProcess()
     typedef itk::NormalizeImageFilter< ImageType, ImageType >  NormalizeFilterType;
     typename NormalizeFilterType::Pointer normalizeFilter = NormalizeFilterType::New();
 
-    normalizeFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( inputData->data() ) ) );
+    normalizeFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( getInputData()->data() ) ) );
 
-    callback = itk::CStyleCommand::New();
+    itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
     callback->SetClientData ( ( void * ) this );
     callback->SetCallback ( itkFiltersProcessBase::eventCallback );
     normalizeFilter->AddObserver ( itk::ProgressEvent(), callback );
 
     normalizeFilter->Update();
 
-    outputData->setData ( normalizeFilter->GetOutput() );
+    getOutputData()->setData ( normalizeFilter->GetOutput() );
 
     //Set output description metadata
-    medUtilities::setDerivedMetaData(outputData, inputData, "normalize filter");
+    medUtilities::setDerivedMetaData(getOutputData(), getInputData(), "normalize filter");
 
     return DTK_SUCCEED;
 }

--- a/src-plugins/itkFilters/itkFiltersNormalizeProcess.h
+++ b/src-plugins/itkFilters/itkFiltersNormalizeProcess.h
@@ -23,8 +23,10 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersNormalizeProcess : public itkFiltersProc
     
 public:
     itkFiltersNormalizeProcess(itkFiltersNormalizeProcess * parent = 0);
-    itkFiltersNormalizeProcess(const itkFiltersNormalizeProcess& other);
+
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersProcessBase.cpp
+++ b/src-plugins/itkFilters/itkFiltersProcessBase.cpp
@@ -17,19 +17,23 @@
 
 #include <medAbstractDataFactory.h>
 
+class itkFiltersProcessBasePrivate
+{
+public:
+    dtkSmartPointer<medAbstractImageData> inputData;
+    dtkSmartPointer<medAbstractImageData> outputData;
+};
+
 itkFiltersProcessBase::itkFiltersProcessBase(itkFiltersProcessBase *parent) 
-    : medAbstractProcess(parent)
+    : medAbstractProcess(parent), d(new itkFiltersProcessBasePrivate)
 {  
-    inputData = NULL;
-    outputData = NULL;
-    
-    descriptionText = "";
+    d->inputData = NULL;
+    d->outputData = NULL;
 }
 
 itkFiltersProcessBase::itkFiltersProcessBase(const itkFiltersProcessBase& other)
-     : medAbstractProcess(other)
+     : medAbstractProcess(other), d(other.d)
 {
-
 }
 
 itkFiltersProcessBase& itkFiltersProcessBase::operator = (const itkFiltersProcessBase& other)
@@ -42,11 +46,6 @@ void itkFiltersProcessBase::emitProgress(int progress)
     emit progressed(progress);
 }
 
-QString itkFiltersProcessBase::description()
-{ 
-    return descriptionText;
-}
-
 void itkFiltersProcessBase::setInput(medAbstractData *data, int channel)
 {
     if (!data)
@@ -54,13 +53,13 @@ void itkFiltersProcessBase::setInput(medAbstractData *data, int channel)
    
     QString identifier = data->identifier();
     
-    outputData = dynamic_cast<medAbstractImageData*> (medAbstractDataFactory::instance()->create(identifier));
-    inputData = dynamic_cast<medAbstractImageData*> (data);
+    d->outputData = dynamic_cast<medAbstractImageData*> (medAbstractDataFactory::instance()->create(identifier));
+    d->inputData = dynamic_cast<medAbstractImageData*> (data);
 }
 
 medAbstractData * itkFiltersProcessBase::output ( void )
 {   
-    return outputData;
+    return d->outputData;
 }
 
 int itkFiltersProcessBase::update()
@@ -88,4 +87,24 @@ void itkFiltersProcessBase::eventCallback ( itk::Object *caller, const itk::Even
     if ( !source ) { dtkWarn() << "Source is null"; }
 
     source->emitProgress((int) (processObject->GetProgress() * 100));
+}
+
+dtkSmartPointer<medAbstractImageData> itkFiltersProcessBase::getInputData()
+{
+    return d->inputData;
+}
+
+void itkFiltersProcessBase::setInputData(dtkSmartPointer<medAbstractImageData> inputData)
+{
+    d->inputData = inputData;
+}
+
+dtkSmartPointer<medAbstractImageData> itkFiltersProcessBase::getOutputData()
+{
+    return d->outputData;
+}
+
+void itkFiltersProcessBase::setOutputData(dtkSmartPointer<medAbstractImageData> outputData)
+{
+    d->outputData = outputData;
 }

--- a/src-plugins/itkFilters/itkFiltersProcessBase.h
+++ b/src-plugins/itkFilters/itkFiltersProcessBase.h
@@ -21,35 +21,16 @@
 #include <medAbstractImageData.h>
 #include <medAbstractProcess.h>
 
+class itkFiltersProcessBasePrivate;
+
 class ITKFILTERSPLUGIN_EXPORT itkFiltersProcessBase : public medAbstractProcess
 {
     Q_OBJECT
 
 public:
-
-    // Default values for itkFiltersProcessBase processes
-    static const double initAddValue       = 100.0;
-    static const double initSubtractValue  = 100.0;
-    static const double initMultiplyFactor = 2.0;
-    static const double initDivideFactor   = 2.0;
-    static const double initSigma          = 1.0;
-    static const double initThreshold          = 200.0;
-    static const int    initOutsideValue       = 0;
-    static const bool   initComparisonOperator = true;
-    static const double initMinimumSize        = 50.0;
-    static const double initMinimumIntensityValue = 0.0;
-    static const double initMaximumIntensityValue = 255.0;
-    static const int    initShrinkFactors(int index)
-    {
-        static const int a[] = {1,1,1};
-        return a[index];
-    }
-
     itkFiltersProcessBase(itkFiltersProcessBase * parent = 0);
     itkFiltersProcessBase(const itkFiltersProcessBase& other);
     itkFiltersProcessBase& operator = (const itkFiltersProcessBase& other);
-
-    QString description ( void );
     
     void setInput ( medAbstractData *data, int channel = 0 );
 
@@ -63,10 +44,13 @@ public:
     static void eventCallback ( itk::Object *caller, const itk::EventObject& event, void *clientData);
 
 protected:
-    QString descriptionText;
-    dtkSmartPointer <medAbstractImageData> inputData;
-    dtkSmartPointer <medAbstractImageData> outputData;
-    itk::CStyleCommand::Pointer callback;
+    dtkSmartPointer<medAbstractImageData> getInputData();
+    void setInputData(dtkSmartPointer<medAbstractImageData> inputData);
+    dtkSmartPointer<medAbstractImageData> getOutputData();
+    void setOutputData(dtkSmartPointer<medAbstractImageData> outputData);
+
+private:
+    itkFiltersProcessBasePrivate *d;
 };
 
 

--- a/src-plugins/itkFilters/itkFiltersShrinkProcess.h
+++ b/src-plugins/itkFilters/itkFiltersShrinkProcess.h
@@ -23,10 +23,14 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersShrinkProcess : public itkFiltersProcess
     Q_OBJECT
     
 public:
+    static const unsigned int defaultShrinkFactors[3];
+
     itkFiltersShrinkProcess(itkFiltersShrinkProcess * parent = 0);
     itkFiltersShrinkProcess(const itkFiltersShrinkProcess& other);
     virtual ~itkFiltersShrinkProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersSubtractProcess.h
+++ b/src-plugins/itkFilters/itkFiltersSubtractProcess.h
@@ -23,10 +23,14 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersSubtractProcess : public itkFiltersProce
     Q_OBJECT
 
 public:
+    static const double defaultSubtractValue;
+
     itkFiltersSubtractProcess(itkFiltersSubtractProcess * parent = 0);
     itkFiltersSubtractProcess(const itkFiltersSubtractProcess& other);
     virtual ~itkFiltersSubtractProcess(void);
     static bool registered(void);
+
+    virtual QString description(void) const;
     
 public slots:
     void setParameter(double data, int channel);

--- a/src-plugins/itkFilters/itkFiltersThresholdingProcess.h
+++ b/src-plugins/itkFilters/itkFiltersThresholdingProcess.h
@@ -23,10 +23,16 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersThresholdingProcess : public itkFiltersP
     Q_OBJECT
     
 public:
+    static const double defaultThreshold;
+    static const int defaultOutsideValue;
+    static const bool defaultComparisonOperator;
+
     itkFiltersThresholdingProcess(itkFiltersThresholdingProcess * parent = 0);
     itkFiltersThresholdingProcess(const itkFiltersThresholdingProcess& other);
     virtual ~itkFiltersThresholdingProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -23,6 +23,15 @@
 #include <dtkCore/dtkSmartPointer.h>
 
 #include <itkFiltersProcessBase.h>
+#include <itkFiltersAddProcess.h>
+#include <itkFiltersComponentSizeThresholdProcess.h>
+#include <itkFiltersDivideProcess.h>
+#include <itkFiltersGaussianProcess.h>
+#include <itkFiltersMultiplyProcess.h>
+#include <itkFiltersShrinkProcess.h>
+#include <itkFiltersSubtractProcess.h>
+#include <itkFiltersThresholdingProcess.h>
+#include <itkFiltersWindowingProcess.h>
 
 #include <medAbstractDataFactory.h>
 #include <medAbstractData.h>
@@ -107,7 +116,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     d->addFilterWidget = new QWidget(this);
     d->addFilterValue = new QDoubleSpinBox;
     d->addFilterValue->setMaximum ( 1000000000 );
-    d->addFilterValue->setValue ( itkFiltersProcessBase::initAddValue );
+    d->addFilterValue->setValue ( itkFiltersAddProcess::defaultAddValue );
     QLabel * addFilterLabel = new QLabel ( tr ( "Constant value:" ) );
     QHBoxLayout * addFilterLayout = new QHBoxLayout;
     addFilterLayout->addWidget ( addFilterLabel );
@@ -119,7 +128,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     d->subtractFilterWidget = new QWidget(this);
     d->subtractFilterValue = new QDoubleSpinBox;
     d->subtractFilterValue->setMaximum ( 1000000000 );
-    d->subtractFilterValue->setValue ( itkFiltersProcessBase::initSubtractValue );
+    d->subtractFilterValue->setValue ( itkFiltersSubtractProcess::defaultSubtractValue );
     QLabel * subtractFilterLabel = new QLabel ( tr ( "Constant value:" ) );
     QHBoxLayout * subtractFilterLayout = new QHBoxLayout;
     subtractFilterLayout->addWidget ( subtractFilterLabel );
@@ -130,7 +139,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     //Multiply filter widgets
     d->multiplyFilterWidget = new QWidget(this);
     d->multiplyFilterValue = new QDoubleSpinBox;
-    d->multiplyFilterValue->setValue ( itkFiltersProcessBase::initMultiplyFactor );
+    d->multiplyFilterValue->setValue ( itkFiltersMultiplyProcess::defaultMultiplyFactor );
     d->multiplyFilterValue->setMaximum ( 1000000000 );
     QLabel * multiplyFilterLabel = new QLabel ( tr ( "Constant value:" ) );
     QHBoxLayout * multiplyFilterLayout = new QHBoxLayout;
@@ -142,7 +151,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     //Divide filter widgets
     d->divideFilterWidget = new QWidget(this);
     d->divideFilterValue = new QDoubleSpinBox;
-    d->divideFilterValue->setValue ( itkFiltersProcessBase::initDivideFactor );
+    d->divideFilterValue->setValue ( itkFiltersDivideProcess::defaultDivideFactor );
     d->divideFilterValue->setMaximum ( 1000000000 );
     d->divideFilterValue->setMinimum(1);
     QLabel * divideFilterLabel = new QLabel ( tr ( "Constant value:" ) );
@@ -155,7 +164,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     //Gaussian filter widgets
     d->gaussianFilterWidget = new QWidget(this);
     d->gaussianFilterValue = new QDoubleSpinBox;
-    d->gaussianFilterValue->setValue ( itkFiltersProcessBase::initSigma );
+    d->gaussianFilterValue->setValue ( itkFiltersGaussianProcess::defaultSigma );
     d->gaussianFilterValue->setMaximum ( 10.0 );
     QLabel * gaussianFilterLabel = new QLabel ( tr ( "Sigma value:" ) );
     QHBoxLayout * gaussianFilterLayout = new QHBoxLayout;
@@ -178,17 +187,17 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     //Shrink filter widgets
     d->shrinkFilterWidget = new QWidget;
     d->shrink0Value = new QSpinBox;
-    d->shrink0Value->setValue (itkFiltersProcessBase::initShrinkFactors(0));
+    d->shrink0Value->setValue (itkFiltersShrinkProcess::defaultShrinkFactors[0]);
     d->shrink0Value->setMinimum ( 1 );
     d->shrink0Value->setMaximum ( 10 );
 
     d->shrink1Value = new QSpinBox;
-    d->shrink1Value->setValue (itkFiltersProcessBase::initShrinkFactors(1));
+    d->shrink1Value->setValue (itkFiltersShrinkProcess::defaultShrinkFactors[1]);
     d->shrink1Value->setMinimum ( 1 );
     d->shrink1Value->setMaximum ( 10 );
 
     d->shrink2Value = new QSpinBox;
-    d->shrink2Value->setValue (itkFiltersProcessBase::initShrinkFactors(2));
+    d->shrink2Value->setValue (itkFiltersShrinkProcess::defaultShrinkFactors[2]);
     d->shrink2Value->setMinimum ( 1 );
     d->shrink2Value->setMaximum ( 10 );
 
@@ -244,12 +253,12 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     d->thresholdFilterWidget = new QWidget(this);
     d->thresholdFilterValue = new QDoubleSpinBox;
     d->thresholdFilterValue->setRange ( -10000, 10000 );
-    d->thresholdFilterValue->setValue ( itkFiltersProcessBase::initThreshold );
+    d->thresholdFilterValue->setValue ( itkFiltersThresholdingProcess::defaultThreshold );
     d->thresholdFilterValue2 = new QSpinBox;
     d->thresholdFilterValue2->setRange ( -10000, 10000 );
-    d->thresholdFilterValue2->setValue ( itkFiltersProcessBase::initOutsideValue );
+    d->thresholdFilterValue2->setValue ( itkFiltersThresholdingProcess::defaultOutsideValue );
     d->greaterButton = new QRadioButton(tr(" greater than: "), this);
-    d->greaterButton->setChecked(itkFiltersProcessBase::initComparisonOperator);
+    d->greaterButton->setChecked(itkFiltersThresholdingProcess::defaultComparisonOperator);
     d->lowerButton = new QRadioButton(tr(" lower than: "), this);
     QLabel * thresholdFilterLabel = new QLabel ( tr ( "Set pixels values  :" ) );
     QLabel * thresholdFilterLabel2 = new QLabel ( tr ( " to :" ) );
@@ -280,7 +289,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     d->componentSizeThresholdFilterValue = new QSpinBox;
     d->componentSizeThresholdFilterValue->setObjectName("Minimum size of an object: ");
     d->componentSizeThresholdFilterValue->setMaximum ( 100000 );
-    d->componentSizeThresholdFilterValue->setValue ( itkFiltersProcessBase::initMinimumSize );
+    d->componentSizeThresholdFilterValue->setValue ( itkFiltersComponentSizeThresholdProcess::defaultMinimumSize );
     QLabel * componentSizeThresholdFilterLabel = new QLabel ( tr ( "Minimum size in pixel of an object:" ) );
     QHBoxLayout * componentSizeThresholdFilterLayout = new QHBoxLayout;
     componentSizeThresholdFilterLayout->addWidget ( componentSizeThresholdFilterLabel );
@@ -362,21 +371,21 @@ medAbstractData* itkFiltersToolBox::processOutput()
 
 void itkFiltersToolBox::clear()
 {
-    d->intensityMinimumValue->setMinimum (itkFiltersProcessBase::initMinimumIntensityValue);
-    d->intensityMinimumValue->setMaximum (itkFiltersProcessBase::initMaximumIntensityValue);
-    d->intensityMinimumValue->setValue (itkFiltersProcessBase::initMinimumIntensityValue);
+    d->intensityMinimumValue->setMinimum (itkFiltersWindowingProcess::defaultMinimumIntensityValue);
+    d->intensityMinimumValue->setMaximum (itkFiltersWindowingProcess::defaultMaximumIntensityValue);
+    d->intensityMinimumValue->setValue (itkFiltersWindowingProcess::defaultMinimumIntensityValue);
 
-    d->intensityMaximumValue->setMinimum (itkFiltersProcessBase::initMinimumIntensityValue);
-    d->intensityMaximumValue->setMaximum (itkFiltersProcessBase::initMaximumIntensityValue);
-    d->intensityMaximumValue->setValue (itkFiltersProcessBase::initMaximumIntensityValue);
+    d->intensityMaximumValue->setMinimum (itkFiltersWindowingProcess::defaultMinimumIntensityValue);
+    d->intensityMaximumValue->setMaximum (itkFiltersWindowingProcess::defaultMaximumIntensityValue);
+    d->intensityMaximumValue->setValue (itkFiltersWindowingProcess::defaultMaximumIntensityValue);
 
-    d->intensityOutputMinimumValue->setMinimum (itkFiltersProcessBase::initMinimumIntensityValue);
-    d->intensityOutputMinimumValue->setMaximum (itkFiltersProcessBase::initMaximumIntensityValue);
-    d->intensityOutputMinimumValue->setValue (itkFiltersProcessBase::initMinimumIntensityValue);
+    d->intensityOutputMinimumValue->setMinimum (itkFiltersWindowingProcess::defaultMinimumIntensityValue);
+    d->intensityOutputMinimumValue->setMaximum (itkFiltersWindowingProcess::defaultMaximumIntensityValue);
+    d->intensityOutputMinimumValue->setValue (itkFiltersWindowingProcess::defaultMinimumIntensityValue);
 
-    d->intensityOutputMaximumValue->setMinimum (itkFiltersProcessBase::initMinimumIntensityValue);
-    d->intensityOutputMaximumValue->setMaximum (itkFiltersProcessBase::initMaximumIntensityValue);
-    d->intensityOutputMaximumValue->setValue (itkFiltersProcessBase::initMaximumIntensityValue);
+    d->intensityOutputMaximumValue->setMinimum (itkFiltersWindowingProcess::defaultMinimumIntensityValue);
+    d->intensityOutputMaximumValue->setMaximum (itkFiltersWindowingProcess::defaultMaximumIntensityValue);
+    d->intensityOutputMaximumValue->setValue (itkFiltersWindowingProcess::defaultMaximumIntensityValue);
 }
 
 void itkFiltersToolBox::update()
@@ -574,8 +583,8 @@ void itkFiltersToolBox::update()
         statsProcess.setInput(data, 0); //data
         statsProcess.setParameter(statsROI::MINMAX);
 
-        double m_MinValueImage = itkFiltersProcessBase::initMinimumIntensityValue;
-        double m_MaxValueImage = itkFiltersProcessBase::initMaximumIntensityValue;
+        double m_MinValueImage = itkFiltersWindowingProcess::defaultMinimumIntensityValue;
+        double m_MaxValueImage = itkFiltersWindowingProcess::defaultMaximumIntensityValue;
 
         if(statsProcess.update() == DTK_SUCCEED)
         {

--- a/src-plugins/itkFilters/itkFiltersWindowingProcess.h
+++ b/src-plugins/itkFilters/itkFiltersWindowingProcess.h
@@ -23,10 +23,15 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersWindowingProcess : public itkFiltersProc
     Q_OBJECT
     
 public:
+    static const double defaultMinimumIntensityValue;
+    static const double defaultMaximumIntensityValue;
+
     itkFiltersWindowingProcess(itkFiltersWindowingProcess * parent = 0);
     itkFiltersWindowingProcess(const itkFiltersWindowingProcess& other);
     virtual ~itkFiltersWindowingProcess(void);
     static bool registered ( void );
+
+    virtual QString description(void) const;
     
 public slots:
 


### PR DESCRIPTION
There were many changes I wanted to request for https://github.com/Inria-Asclepios/medInria-public/pull/282 but instead of asking @mathildemerle to make them I did them myself to gain time. This PR is to be merged onto @mathildemerle's branch, so that once we merge this the original PR will have the modifications.

The changes are:

- I moved the default values from ```itkFiltersProcessBase``` to each of the derived classes where I think they should be (so for example, the default add value is in the add process class).
- Initialisation of double members has to be done outside the class to be portable standard C++, so I moved all the initialisation of the default members out of the classes.
- ```itkFiltersProcessBase``` had protected member variables (e.g. inputData). This is discouraged in object oriented programming so I moved them to a private implementation and added getters and setters.
- I removed ```descriptionText``` as it is not needed. The derived classes simply have to override ```description()``` like we do elsewhere.
- There is no need to keep a pointer to the callback command so I removed it.
- I hadn't noticed that the original copy constructors did not do anything. I added the copying of the private implementation pointer (d) in the classes that have them. As for the classes that don't have any data to copy, the default copy constructor is sufficient so I removed them.